### PR TITLE
chore: migrate project workflow from npm to pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,9 @@ Kairo is built using the stable Script API:
 
 1. Install dependencies:
     ```bash
-    npm install
+    pnpm install
     ```
 2. Deploy
     ```bash
-    npm run build
-    ```
-3. Auto-deploy on file change:
-    ```bash
-    npm run dev
+    pnpm run build
     ```

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
     "description": "**Stable Script API**\r - @minecraft/server - 2.5.0",
     "main": "index.js",
     "type": "module",
+    "packageManager": "pnpm@10.31.0",
     "scripts": {
         "typecheck": "tsc --noEmit",
-        "build": "rimraf BP/scripts && npm run typecheck && node build.mjs && npm run deploy",
+        "build": "rimraf BP/scripts && pnpm run typecheck && node build.mjs && pnpm run deploy",
         "deploy": "node src/deploy.js"
     },
     "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
         // For nodejs:
         // "lib": ["esnext"],
         // "types": ["node"],
-        // and npm install -D @types/node
+        // and pnpm add -D @types/node
 
         // Other Outputs
         "sourceMap": false,


### PR DESCRIPTION
### Motivation
- Move the repository from an npm-centric developer workflow to use `pnpm` as the package manager and standardize developer instructions accordingly.
- Ensure the existing esbuild-driven build flow remains intact while switching command invocations to `pnpm`.

### Description
- Add `"packageManager": "pnpm@10.31.0"` to `package.json` to declare the desired pnpm version. 
- Update the `build` script in `package.json` to call `pnpm run` instead of `npm run` while preserving the `node build.mjs` (esbuild) step and `deploy` invocation. 
- Update `README.md` setup instructions to use `pnpm install` and `pnpm run build`, and remove the inaccurate `dev` command guidance. 
- Replace an inline developer comment in `tsconfig.json` to recommend `pnpm add -D @types/node` instead of an `npm` instruction.

### Testing
- Ran `npx tsc --noEmit` to verify TypeScript typechecking, which succeeded. 
- Ran `node build.mjs` to exercise the esbuild-based bundling step, which completed without errors. 
- Attempted `corepack pnpm@10.31.0 install` to install the exact pnpm version, but the environment failed to fetch the pnpm tarball (HTTP tunneling/proxy 403), so lockfile/installation with that exact version could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf9adf6388333802d78796569e982)